### PR TITLE
Fix formatting sdcard failure with Make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -358,7 +358,7 @@ $(vfat_image): $(fit) $(confdir)/uEnv.txt
 endif
 $(flash_image): $(uboot) $(fit) $(vfat_image)
 	dd if=/dev/zero of=$(flash_image) bs=1M count=32
-	/sbin/sgdisk --clear  \
+	/sbin/sgdisk --clear -g  \
 		--new=1:$(VFAT_START):$(VFAT_END)  --change-name=1:"Vfat Boot"	--typecode=1:$(VFAT)   \
 		--new=2:$(UBOOT_START):$(UBOOT_END)   --change-name=2:uboot	--typecode=2:$(UBOOT) \
 		--new=3:$(UENV_START):$(UENV_END)   --change-name=3:uboot-env	--typecode=3:$(UBOOTENV) \
@@ -382,7 +382,7 @@ DEMO_END=11718750
 .PHONY: format-boot-loader
 format-boot-loader: $(bbl_bin) $(uboot) $(fit) $(vfat_image)
 	@test -b $(DISK) || (echo "$(DISK): is not a block device"; exit 1)
-	/sbin/sgdisk --clear  \
+	/sbin/sgdisk --clear -g \
 		--new=1:$(VFAT_START):$(VFAT_END)  --change-name=1:"Vfat Boot"	--typecode=1:$(VFAT)   \
 		--new=2:$(UBOOT_START):$(UBOOT_END)   --change-name=2:uboot	--typecode=2:$(UBOOT) \
 		--new=3:$(UENV_START):$(UENV_END)  --change-name=3:uboot-env	--typecode=3:$(UBOOTENV) \
@@ -445,7 +445,7 @@ ROOT_END=$(shell echo $$(($(ROOT_BEGIN)+$(ROOT_CLUSTER_NUM))))
 
 format-nvdla-disk: $(bbl_bin) $(uboot) $(fit) $(vfat_image)
 	@test -b $(DISK) || (echo "$(DISK): is not a block device"; exit 1)
-	/sbin/sgdisk --clear  \
+	/sbin/sgdisk --clear -g  \
 		--new=1:$(VFAT_START):$(VFAT_END)  --change-name=1:"Vfat Boot"  --typecode=1:$(VFAT)   \
 		--new=2:$(UBOOT_START):$(UBOOT_END)   --change-name=2:uboot --typecode=2:$(UBOOT) \
 		--new=3:$(ROOT_BEGIN):0 --change-name=3:root  --typecode=3:$(LINUX) \
@@ -475,7 +475,7 @@ endif
 
 format-usb-disk: sbi $(uboot) $(fit) $(vfat_image)
 	@test -b $(DISK) || (echo "$(DISK): is not a block device"; exit 1)
-	/sbin/sgdisk --clear  \
+	/sbin/sgdisk --clear -g \
 	--new=1:0:+256M  --change-name=1:"Vfat Boot"  --typecode=1:$(VFAT)   \
 	--new=2:0:+1G   --change-name=2:uboot --typecode=2:$(UBOOT) -g\
 	$(DISK)


### PR DESCRIPTION
`$:~/beaglev/beagle_freedom_u_sdk$ sudo make DISK=/dev/sda format-nvdla-disk `

`/sbin/sgdisk --clear  \
	--new=1:4096:270335  --change-name=1:"Vfat Boot"  --typecode=1:EBD0A0A2-B9E5-4433-87C0-68B6B72699C7   \
	--new=2:270336:272383   --change-name=2:uboot --typecode=2:5B193300-FC78-40CD-8002-E86C45580B47 \
	--new=3:272384:0 --change-name=3:root  --typecode=3:0FC63DAF-8483-4772-8E79-3D69D8477DE4 \
	/dev/sda
Setting name!
partNum is 0
Setting name!
partNum is 1
Setting name!
partNum is 2
The operation has completed successfully.`

`/sbin/partprobe
Error: Could not find bootloader partition for /dev/sda
make: *** [Makefile:479: format-nvdla-disk] Error 1`

Use sgdisk '-g' override option to fix this