### PR TITLE
sf-omx-il: starfive video encoder support bitrate control

### DIFF
--- a/soft_3rdpart/omx-il/component/video/enc/SF_OMX_Venc_encoder.c
+++ b/soft_3rdpart/omx-il/component/video/enc/SF_OMX_Venc_encoder.c
@@ -852,7 +852,16 @@ static OMX_ERRORTYPE InitEncoder(SF_OMX_COMPONENT *pSfOMXComponent)
     CNMComponentConfig *pCNMComponentConfig = (CNMComponentConfig*)pSfOMXComponent->config;
     config->encOpenParam.picWidth = pSfOMXComponent->portDefinition[0].format.video.nFrameWidth;
     config->encOpenParam.picHeight = pSfOMXComponent->portDefinition[0].format.video.nFrameHeight;
-    config->encOpenParam.frameRateInfo = pSfOMXComponent->portDefinition[0].format.video.xFramerate;
+
+    /* If xFramerate value from user is stored in Q16 format, should convert into integer */
+    if(pSfOMXComponent->portDefinition[0].format.video.xFramerate > (1 << 16))
+    {
+        config->encOpenParam.frameRateInfo = pSfOMXComponent->portDefinition[0].format.video.xFramerate >> 16;
+    }
+    else
+    {
+        config->encOpenParam.frameRateInfo = pSfOMXComponent->portDefinition[0].format.video.xFramerate;
+    }
 
     if(pSfOMXComponent->portDefinition[1].format.video.nBitrate)
     {

--- a/soft_3rdpart/omx-il/component/video/enc/SF_OMX_Venc_encoder.c
+++ b/soft_3rdpart/omx-il/component/video/enc/SF_OMX_Venc_encoder.c
@@ -853,7 +853,17 @@ static OMX_ERRORTYPE InitEncoder(SF_OMX_COMPONENT *pSfOMXComponent)
     config->encOpenParam.picWidth = pSfOMXComponent->portDefinition[0].format.video.nFrameWidth;
     config->encOpenParam.picHeight = pSfOMXComponent->portDefinition[0].format.video.nFrameHeight;
     config->encOpenParam.frameRateInfo = pSfOMXComponent->portDefinition[0].format.video.xFramerate;
-    config->encOpenParam.bitRate = pSfOMXComponent->portDefinition[1].format.video.nBitrate;
+
+    if(pSfOMXComponent->portDefinition[1].format.video.nBitrate)
+    {
+        config->encOpenParam.rcEnable = 1;
+        config->encOpenParam.bitRate = pSfOMXComponent->portDefinition[1].format.video.nBitrate;
+    }
+    else if(config->encOpenParam.rcEnable == 1)
+    {
+        pSfOMXComponent->portDefinition[1].format.video.nBitrate = config->encOpenParam.bitRate;
+    }
+
     if (pSfOMXComponent->bitFormat == STD_AVC)
     {
         config->encOpenParam.EncStdParam.waveParam.intraPeriod = pSfOMXComponent->AVCComponent[1].nPFrames;


### PR DESCRIPTION
wave series encoder support regular bitrate parameter. To enable bitrate
control, you can modify the "RateControl" item in encoder_defconfig.cfg,
and set the bitrate to "EncBitrate" item in bps.
eg:
	RateControl : 1
	EncBitrate : 7000000
Or you can set the property when using gstreamer.
eg:
	omxh264enc target-bitrate=7000000

Signed-off-by: Som Qin <som.qin@starfivetech.com>