### PR TITLE
wave521, wave511: fix VPU issue when forced to stop

### DIFF
--- a/soft_3rdpart/wave511/code/vdi/linux/vdi.c
+++ b/soft_3rdpart/wave511/code/vdi/linux/vdi.c
@@ -1210,7 +1210,10 @@ void vdi_free_dma_memory(unsigned long core_idx, vpu_buffer_t *vb, int memTypes,
     vmem_lock(vdi);
     for (i=0; i<MAX_VPU_BUFFER_POOL; i++)
     {
-        if (vdi->vpu_buffer_pool[i].vdb.phys_addr == vb->phys_addr)
+        /* add more constraints for finding the correct buffer */
+        if ((vdi->vpu_buffer_pool[i].vdb.phys_addr == vb->phys_addr)
+			&& (vdi->vpu_buffer_pool[i].vdb.size == vb->size)
+			&& (vdi->vpu_buffer_pool[i].vdb.virt_addr == vb->virt_addr))
         {
             vdi->vpu_buffer_pool[i].inuse = 0;
             vdi->vpu_buffer_pool_count--;

--- a/soft_3rdpart/wave511/code/vpuapi/vpuapi.c
+++ b/soft_3rdpart/wave511/code/vpuapi/vpuapi.c
@@ -184,11 +184,14 @@ static RetCode InitializeVPU(Uint32 coreIdx, const Uint16* code, Uint32 size)
         }
     }
 
+    /* force to reset vpu, so that the vpu in a clean state */
+#if 0
     if (VPU_IsInit(coreIdx) != 0) {
         ProductVpuReInit(coreIdx, (void *)code, size);
         LeaveLock(coreIdx);
         return RETCODE_CALLED_BEFORE;
     }
+#endif
 
     InitCodecInstancePool(coreIdx);
 

--- a/soft_3rdpart/wave521/code/vdi/linux/vdi.c
+++ b/soft_3rdpart/wave521/code/vdi/linux/vdi.c
@@ -1139,7 +1139,10 @@ void vdi_free_dma_memory(unsigned long core_idx, vpu_buffer_t *vb, int memTypes,
     vmem_lock(vdi);
     for (i=0; i<MAX_VPU_BUFFER_POOL; i++)
     {
-        if (vdi->vpu_buffer_pool[i].vdb.phys_addr == vb->phys_addr)
+        /* add more constraints for finding the correct buffer */
+        if ((vdi->vpu_buffer_pool[i].vdb.phys_addr == vb->phys_addr)
+			&& (vdi->vpu_buffer_pool[i].vdb.size == vb->size)
+			&& (vdi->vpu_buffer_pool[i].vdb.virt_addr == vb->virt_addr))
         {
             vdi->vpu_buffer_pool[i].inuse = 0;
             vdi->vpu_buffer_pool_count--;

--- a/soft_3rdpart/wave521/code/vpuapi/vpuapi.c
+++ b/soft_3rdpart/wave521/code/vpuapi/vpuapi.c
@@ -184,11 +184,14 @@ static RetCode InitializeVPU(Uint32 coreIdx, const Uint16* code, Uint32 size)
         }
     }
 
+    /* force to reset vpu, so that the vpu in a clean state */
+#if 0
     if (VPU_IsInit(coreIdx) != 0) {
         ProductVpuReInit(coreIdx, (void *)code, size);
         LeaveLock(coreIdx);
         return RETCODE_CALLED_BEFORE;
     }
+#endif
 
     InitCodecInstancePool(coreIdx);
 


### PR DESCRIPTION
1. When user forces to stop the encoding/decoding right after it
   starts to run, the VPU may enter an unstable state
   (instance is not correctly destoried, memory not freed).
   And the VPU will hang in the next run.
   Reset the VPU whenever it was initialized.
2. The vdi may free a wrong dma buffer when VPU forced to stop,
   as vdi only checks the physical address to find the corresponding dma buffer.
   Add more constraints for finding the correct dma buffer before
   freeing it.

Signed-off-by: mason.huo <mason.huo@starfivetech.com>