### PR TITLE
Adjust Vdec and Venc driver

### DIFF
--- a/soft_3rdpart/wave511/code/vdi/linux/driver/vdec.c
+++ b/soft_3rdpart/wave511/code/vdi/linux/driver/vdec.c
@@ -1969,7 +1969,7 @@ static int _clk_control(int enable)
     else
     {
         _disable_clk(p_breg+clk_vdec_axi_ctrl_REG_OFFSET,31);
-        _disable_clk(p_breg+clk_vdecbrg_mainclk_ctrl_REG_OFFSET,31);
+        // _disable_clk(p_breg+clk_vdecbrg_mainclk_ctrl_REG_OFFSET,31);
         _disable_clk(p_breg+clk_vdec_bclk_ctrl_REG_OFFSET,31);
         _disable_clk(p_breg+clk_vdec_cclk_ctrl_REG_OFFSET,31);
         _disable_clk(p_breg+clk_vdec_apb_ctrl_REG_OFFSET,31);

--- a/soft_3rdpart/wave521/code/vdi/linux/driver/venc.c
+++ b/soft_3rdpart/wave521/code/vdi/linux/driver/venc.c
@@ -1923,7 +1923,7 @@ static int _clk_control(int enable)
     else
     {
         _disable_clk(p_breg+clk_venc_axi_ctrl_REG_OFFSET,31);
-        _disable_clk(p_breg+clk_vencbrg_mainclk_ctrl_REG_OFFSET,31);
+        // _disable_clk(p_breg+clk_vencbrg_mainclk_ctrl_REG_OFFSET,31);
         _disable_clk(p_breg+clk_venc_bclk_ctrl_REG_OFFSET,31);
         _disable_clk(p_breg+clk_venc_cclk_ctrl_REG_OFFSET,31);
         _disable_clk(p_breg+clk_venc_apb_ctrl_REG_OFFSET,31);


### PR DESCRIPTION
vdec.c/venc.c: not disable clock of 'vdecbrg_main' and 'vencbrg_main'.

Signed-off-by: Xingyu Wu <xingyu.wu@starfivetech.com>